### PR TITLE
:recycle: refactor: Auth 관련 코드 수정 및 yml 설정 추가

### DIFF
--- a/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
+++ b/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
@@ -17,7 +17,7 @@ import com.roome.global.security.jwt.exception.InvalidJwtTokenException;
 import com.roome.global.security.jwt.exception.InvalidUserIdFormatException;
 import com.roome.global.security.jwt.exception.MissingUserIdFromTokenException;
 import com.roome.global.security.jwt.principal.CustomUser;
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
 import com.roome.global.service.RedisService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -110,7 +110,7 @@ public class AuthController {
 									   HttpServletRequest request, HttpServletResponse response
 	) {
 		authService.logout(user.getId(), request, response);
-		return ResponseEntity.ok().build();
+		return ResponseEntity.noContent().build();
 	}
 
 	@Operation(summary = "회원 탈퇴", description = "현재 로그인된 사용자 계정을 삭제합니다.", security = @SecurityRequirement(name = "bearerAuth"))

--- a/roome/src/main/java/com/roome/domain/auth/service/AuthService.java
+++ b/roome/src/main/java/com/roome/domain/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.roome.domain.auth.service;
 
 import com.roome.global.security.jwt.service.RefreshTokenService;
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +36,7 @@ public class AuthService {
 			blacklistRedisTemplate.opsForValue().set("blacklist:" + accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
 		}
 
+		// 쿠키 refreshToken 삭젠
 		ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
 				.httpOnly(true)
 				.secure(true)

--- a/roome/src/main/java/com/roome/global/config/JwtSecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/JwtSecurityConfig.java
@@ -1,7 +1,7 @@
 package com.roome.global.config;
 
 import com.roome.global.security.filter.JwtAuthenticationFilter;
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.roome.global.config;
 
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
 import com.roome.global.security.oauth.handler.OAuth2AuthenticationFailureHandler;
 import com.roome.global.security.oauth.handler.OAuth2AuthenticationSuccessHandler;
 import com.roome.global.security.oauth.service.CustomOAuth2UserService;

--- a/roome/src/main/java/com/roome/global/config/WebSocketConfig.java
+++ b/roome/src/main/java/com/roome/global/config/WebSocketConfig.java
@@ -1,7 +1,7 @@
 package com.roome.global.config;
 
 import com.roome.global.security.jwt.interceptor.JwtWebSocketInterceptor;
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
 import com.roome.global.service.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/roome/src/main/java/com/roome/global/security/filter/JwtAuthenticationFilter.java
+++ b/roome/src/main/java/com/roome/global/security/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,7 @@
 package com.roome.global.security.filter;
 
 import com.roome.global.security.jwt.exception.InvalidJwtTokenException;
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;

--- a/roome/src/main/java/com/roome/global/security/jwt/controller/TokenController.java
+++ b/roome/src/main/java/com/roome/global/security/jwt/controller/TokenController.java
@@ -23,8 +23,9 @@ public class TokenController {
 	// 임시 코드로 토큰 교환 api
 	@PostMapping("/temp")
 	public ResponseEntity<Void> exchangeTempCode(@RequestBody GetAccessTokenByTempCodeRequest getAccessTokenByTempCodeRequest,
+												 HttpServletRequest request,
 												 HttpServletResponse response) {
-		tempTokenService.exchangeTempCode(getAccessTokenByTempCodeRequest, response);
+		tempTokenService.exchangeTempCode(getAccessTokenByTempCodeRequest, request, response);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/roome/src/main/java/com/roome/global/security/jwt/interceptor/JwtWebSocketInterceptor.java
+++ b/roome/src/main/java/com/roome/global/security/jwt/interceptor/JwtWebSocketInterceptor.java
@@ -2,7 +2,7 @@ package com.roome.global.security.jwt.interceptor;
 
 import com.roome.global.exception.BusinessException;
 import com.roome.global.exception.ErrorCode;
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
 import com.roome.global.service.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/roome/src/main/java/com/roome/global/security/jwt/provider/JwtTokenProvider.java
+++ b/roome/src/main/java/com/roome/global/security/jwt/provider/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.roome.global.security.jwt.token;
+package com.roome.global.security.jwt.provider;
 
 import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
@@ -68,6 +68,7 @@ public class JwtTokenProvider implements InitializingBean {
 
 		return Jwts.builder()
 				.setSubject(String.valueOf(userId))
+				.claim("userId", String.valueOf(userId))
 				.claim(AUTHORITIES_KEY, authorities) // 정보 저장
 				.signWith(key, SignatureAlgorithm.HS256) // 사용할 암호화 알고리즘과 , signature 에 들어갈 secret값 세팅
 				.setExpiration(validity) // set Expire Time 해당 옵션 안넣으면 expire안함
@@ -77,7 +78,7 @@ public class JwtTokenProvider implements InitializingBean {
 	public String createRefreshToken(Long userId) {
 		Date now = new Date();
 		long refreshTokenValidity = 2592000000L;
-		Date expiry = new Date(now.getTime() + refreshTokenValidity); // 2주 등
+		Date expiry = new Date(now.getTime() + refreshTokenValidity);
 
 		return Jwts.builder()
 				.setSubject(String.valueOf(userId))

--- a/roome/src/main/java/com/roome/global/security/jwt/service/TokenExchangeService.java
+++ b/roome/src/main/java/com/roome/global/security/jwt/service/TokenExchangeService.java
@@ -1,23 +1,26 @@
 package com.roome.global.security.jwt.service;
 
 import com.roome.global.security.jwt.dto.GetAccessTokenByTempCodeRequest;
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.UUID;
+
+import static com.roome.global.security.jwt.util.TokenResponseUtil.addTokensToResponse;
 
 @Service
 @RequiredArgsConstructor
 public class TokenExchangeService {
 
 	private static final long EXPIRATION_MINUTES = 3;
+	private static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(14);
 	@Qualifier("tempCodeRedisTemplate")
 	private final RedisTemplate<String, String> tempCodeRedisTemplate;
 	private final JwtTokenProvider jwtTokenProvider;
@@ -29,7 +32,7 @@ public class TokenExchangeService {
 		return tempCode;
 	}
 
-	public void exchangeTempCode(GetAccessTokenByTempCodeRequest getAccessTokenByTempCodeRequest,
+	public void exchangeTempCode(GetAccessTokenByTempCodeRequest getAccessTokenByTempCodeRequest, HttpServletRequest request,
 								 HttpServletResponse response) {
 		String accessToken = getAccessTokenByTempCode(getAccessTokenByTempCodeRequest.getTempCode());
 		Long userId = jwtTokenProvider.getUserIdFromAccessToken(accessToken);
@@ -38,25 +41,16 @@ public class TokenExchangeService {
 		String refreshToken = jwtTokenProvider.createRefreshToken(userId);
 
 		// refreshToken redis 에 저장
-		refreshTokenService.saveRefreshToken(userId, refreshToken);
+		refreshTokenService.saveRefreshToken(userId, refreshToken, request);
 
 		// accessToken: Header로 전달
 		response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
 
-		// refreshToken: Cookie로 전달
-		ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
-				.httpOnly(true)
-				.secure(true)
-				.sameSite("None")
-				.path("/")
-				.maxAge(Duration.ofDays(14))
-				.build();
-		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+		addTokensToResponse(response, accessToken, refreshToken);
 	}
 
 	private String getAccessTokenByTempCode(String tempCode) {
 		String accessTokenFromRedis = tempCodeRedisTemplate.opsForValue().get(tempCode);
-		if (accessTokenFromRedis == null) throw new IllegalArgumentException("유효하지 않은 임시 코드입니다.");
 		tempCodeRedisTemplate.delete(tempCode);
 		return accessTokenFromRedis;
 	}

--- a/roome/src/main/java/com/roome/global/security/jwt/service/TokenService.java
+++ b/roome/src/main/java/com/roome/global/security/jwt/service/TokenService.java
@@ -1,37 +1,60 @@
 package com.roome.global.security.jwt.service;
 
 import com.roome.global.security.jwt.exception.InvalidRefreshTokenException;
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+import java.util.Objects;
+
+import static com.roome.global.security.jwt.util.TokenResponseUtil.addTokensToResponse;
+
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class TokenService {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RefreshTokenService refreshTokenService;
 
-
 	public void refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
-		String refreshToken = extractRefreshTokenFromCookie(request);
-
-		if (refreshToken == null || !jwtTokenProvider.validateRefreshToken(refreshToken))
-			throw new InvalidRefreshTokenException();
-
+		String refreshToken = extractAndValidateRefreshToken(request);
 		Long userId = jwtTokenProvider.getUserFromRefreshToken(refreshToken);
-		String savedToken = refreshTokenService.getRefreshToken(userId);
-		if (!refreshToken.equals(savedToken)) throw new InvalidRefreshTokenException();
+
+		Map<String, String> stored = validateStoredToken(userId, refreshToken);
+		validateClientFingerprint(userId, request, stored);
 
 		Authentication authentication = jwtTokenProvider.getAuthenticationFromUserId(userId);
-		String newAccessToken = jwtTokenProvider.createToken(authentication);
 
-		response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken);
+		String newAccessToken = jwtTokenProvider.createToken(authentication);
+		String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+		refreshTokenService.deleteRefreshToken(userId);
+		refreshTokenService.saveRefreshToken(userId, newRefreshToken, request);
+
+		addTokensToResponse(response, newAccessToken, newRefreshToken);
+	}
+
+	private String extractAndValidateRefreshToken(HttpServletRequest request) {
+		String token = extractRefreshTokenFromCookie(request);
+		if (token == null || !jwtTokenProvider.validateRefreshToken(token)) {
+			throw new InvalidRefreshTokenException();
+		}
+		return token;
+	}
+
+	private Map<String, String> validateStoredToken(Long userId, String refreshToken) {
+		Map<String, String> stored = refreshTokenService.getStoredFingerprint(userId);
+		if (stored == null || !refreshToken.equals(stored.get("token"))) {
+			throw new InvalidRefreshTokenException();
+		}
+		return stored;
 	}
 
 	private String extractRefreshTokenFromCookie(HttpServletRequest request) {
@@ -42,5 +65,20 @@ public class TokenService {
 			if ("refreshToken".equals(cookie.getName())) return cookie.getValue();
 		}
 		return null;
+	}
+
+	private void validateClientFingerprint(Long userId, HttpServletRequest request, Map<String, String> stored) {
+		if (stored.isEmpty()) throw new InvalidRefreshTokenException();
+
+		String storedIp = stored.get("ip");
+		String storedUa = stored.get("userAgent");
+
+		String requestIp = request.getRemoteAddr();
+		String requestUa = request.getHeader("User-Agent");
+
+		if (!Objects.equals(storedIp, requestIp) || !Objects.equals(storedUa, requestUa)) {
+			log.warn("[환경 변경 감지] userId={}, oldIp={}, newIp={}, oldUA={}, newUA={}",
+					userId, storedIp, requestIp, storedUa, requestUa);
+		}
 	}
 }

--- a/roome/src/main/java/com/roome/global/security/jwt/util/TokenResponseUtil.java
+++ b/roome/src/main/java/com/roome/global/security/jwt/util/TokenResponseUtil.java
@@ -1,0 +1,24 @@
+package com.roome.global.security.jwt.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+
+public class TokenResponseUtil {
+
+    private static final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(14);
+
+    public static void addTokensToResponse(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(REFRESH_TOKEN_DURATION)
+                .build();
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/roome/src/main/java/com/roome/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/roome/src/main/java/com/roome/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,7 +1,7 @@
 package com.roome.global.security.oauth.handler;
 
 import com.roome.global.security.jwt.service.TokenExchangeService;
-import com.roome.global.security.jwt.token.JwtTokenProvider;
+import com.roome.global.security.jwt.provider.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/roome/src/main/resources/application.yml
+++ b/roome/src/main/resources/application.yml
@@ -59,6 +59,8 @@ spring:
       port: ${REDIS_PORT}
       host: ${REDIS_HOST}
       password: ${REDIS_PASSWORD}
+  server:
+    forward-headers-strategy: framework
 
 # OAuth2 리디렉션 설정 - 공통 설정
 # 백엔드 → 프론트엔드 리다이렉트 (SuccessHandler 에서 사용)
@@ -105,9 +107,9 @@ spring:
       on-profile: local
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: ${LOCAL_DATASOURCE_URL}
-    username: ${LOCAL_DATASOURCE_USERNAME}
-    password: ${LOCAL_DATASOURCE_PASSWORD}
+    url: ${DATASOURCE_URL}
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: update
@@ -139,9 +141,9 @@ spring:
       on-profile: dev
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: ${DATASOURCE_URL}
-    username: ${DATASOURCE_USERNAME}
-    password: ${DATASOURCE_PASSWORD}
+    url: ${LOCAL_DATASOURCE_URL}
+    username: ${LOCAL_DATASOURCE_USERNAME}
+    password: ${LOCAL_DATASOURCE_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 📌 Auth 관련 코드 수정 및 yml 설정 추가

### ✅ PR 설명

보안 고려해 Auth 관련 코드 리팩토링
**yml 설정 추가-> server.forward-headers-strategy: framework 

### 🏗 작업 내용

- [ ] refreshToken redis 에 저장시 사용자 환경 정보 저장
- [ ] 이후 AccessToken 재발급 후 RefreshToken 환경 설정 변경 사항 있을 시 로그 남도록 수정
- [ ] application.yml forward-headers-strategy 설정 framework 추가

### 📸 테스트 결과 (선택)

> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)

> #12 

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
