### PR TITLE
:recycle: fix: JwtTokenProvider token 생성 시 Claims 에 email 추가

### DIFF
--- a/roome/src/main/java/com/roome/global/security/jwt/principal/CustomUser.java
+++ b/roome/src/main/java/com/roome/global/security/jwt/principal/CustomUser.java
@@ -54,4 +54,7 @@ public class CustomUser implements UserDetails, UserPrincipal {
 	public Long getId() {
 		return id;
 	}
+
+	@Override
+	public String getEmail() {return email;}
 }

--- a/roome/src/main/java/com/roome/global/security/jwt/principal/UserPrincipal.java
+++ b/roome/src/main/java/com/roome/global/security/jwt/principal/UserPrincipal.java
@@ -3,4 +3,5 @@ package com.roome.global.security.jwt.principal;
 public interface UserPrincipal {
 
 	Long getId();
+	String getEmail();
 }

--- a/roome/src/main/java/com/roome/global/security/jwt/provider/JwtTokenProvider.java
+++ b/roome/src/main/java/com/roome/global/security/jwt/provider/JwtTokenProvider.java
@@ -65,10 +65,12 @@ public class JwtTokenProvider implements InitializingBean {
 
 		UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
 		Long userId = principal.getId();
+		String email = principal.getEmail();
 
 		return Jwts.builder()
 				.setSubject(String.valueOf(userId))
 				.claim("userId", String.valueOf(userId))
+				.claim("email", email)
 				.claim(AUTHORITIES_KEY, authorities) // 정보 저장
 				.signWith(key, SignatureAlgorithm.HS256) // 사용할 암호화 알고리즘과 , signature 에 들어갈 secret값 세팅
 				.setExpiration(validity) // set Expire Time 해당 옵션 안넣으면 expire안함

--- a/roome/src/main/java/com/roome/global/security/oauth/model/CustomOAuth2User.java
+++ b/roome/src/main/java/com/roome/global/security/oauth/model/CustomOAuth2User.java
@@ -19,6 +19,11 @@ public class CustomOAuth2User implements OAuth2User, UserPrincipal {
 	private final Long id;
 
 	@Override
+	public <A> A getAttribute(String name) {
+		return OAuth2User.super.getAttribute(name);
+	}
+
+	@Override
 	public Map<String, Object> getAttributes() {
 		return attributes;
 	}
@@ -30,12 +35,17 @@ public class CustomOAuth2User implements OAuth2User, UserPrincipal {
 
 	@Override
 	public String getName() {
-		return user.getEmail();
+		return user.getName();
 	}
 
 	@Override
 	public Long getId() {
 		return id;
+	}
+
+	@Override
+	public String getEmail() {
+		return user.getEmail();
 	}
 
 	public User getUser() {


### PR DESCRIPTION
## 📌 배포 서버 User 조회 오류 의심 사항 수정

### ✅ PR 설명

JwtTokenProvider token 생성 시 Claims 에 email 추가

### 🏗 작업 내용

- [ ] JwtTokenProvider token 생성 시 Claims 에 email 추가
- [ ] UserPrincipal 에 email 필드 추가
- [ ] CustomUser, CustomOAuth2User email 추가

### 📸 테스트 결과 (선택)

> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)

> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
