### PR TITLE
Feat/#28 최초 로그인 시 성별, 연령대 수집 구현

### DIFF
--- a/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
+++ b/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
@@ -43,8 +43,6 @@ public class AuthController {
 	private final RoomService roomService;
 	private final FurnitureRepository furnitureRepository;
 	private final AuthService authService;
-	private final JwtTokenProvider jwtTokenProvider;
-	private final RefreshTokenService refreshTokenService;
 
 	@Operation(summary = "사용자 정보 조회", description = "Access Token으로 사용자 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),

--- a/roome/src/main/java/com/roome/domain/user/controller/UserProfileController.java
+++ b/roome/src/main/java/com/roome/domain/user/controller/UserProfileController.java
@@ -32,7 +32,7 @@ public class UserProfileController {
 
 	// 신규 user 나이대, 성별 조회 api
 	@PatchMapping("/{userId}/profile")
-	public ResponseEntity<Void> setProfileInfo(@AuthenticationPrincipal CustomUser user, @PathVariable Long userId, SetProfileInfoRequest setProfileInfoRequest) {
+	public ResponseEntity<Void> setProfileInfo(@PathVariable Long userId, @RequestBody SetProfileInfoRequest setProfileInfoRequest) {
 		userProfileService.setProfileInfo(userId, setProfileInfoRequest);
 		return ResponseEntity.ok().build();
 	}

--- a/roome/src/main/java/com/roome/domain/user/controller/UserProfileController.java
+++ b/roome/src/main/java/com/roome/domain/user/controller/UserProfileController.java
@@ -1,5 +1,6 @@
 package com.roome.domain.user.controller;
 
+import com.roome.domain.user.dto.request.SetProfileInfoRequest;
 import com.roome.domain.user.dto.request.UpdateProfileRequest;
 import com.roome.domain.user.dto.response.UserProfileResponse;
 import com.roome.domain.user.service.UserProfileService;
@@ -28,6 +29,13 @@ import org.springframework.web.bind.annotation.*;
 public class UserProfileController {
 
 	private final UserProfileService userProfileService;
+
+	// 신규 user 나이대, 성별 조회 api
+	@PatchMapping("/{userId}/profile")
+	public ResponseEntity<Void> setProfileInfo(@AuthenticationPrincipal CustomUser user, @PathVariable Long userId, SetProfileInfoRequest setProfileInfoRequest) {
+		userProfileService.setProfileInfo(userId, setProfileInfoRequest);
+		return ResponseEntity.ok().build();
+	}
 
 	@Operation(summary = "프로필 조회",
 			description = "특정 사용자의 프로필 정보를 조회합니다.")

--- a/roome/src/main/java/com/roome/domain/user/dto/request/SetProfileInfoRequest.java
+++ b/roome/src/main/java/com/roome/domain/user/dto/request/SetProfileInfoRequest.java
@@ -1,0 +1,20 @@
+package com.roome.domain.user.dto.request;
+
+import com.roome.domain.user.entity.Gender;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SetProfileInfoRequest {
+    @NotBlank
+    private Gender gender;
+
+    @NotBlank
+    @Min(1900)
+    @Max(2025)
+    private Integer birthYear;
+}

--- a/roome/src/main/java/com/roome/domain/user/entity/Gender.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/Gender.java
@@ -1,0 +1,17 @@
+package com.roome.domain.user.entity;
+
+public enum Gender {
+    MALE("남성"),
+    FEMALE("여성"),
+    NONE("비공개");
+
+    private final String displayName;
+
+    Gender(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import com.roome.domain.point.entity.Point;
 import com.roome.domain.rank.entity.UserActivity;
 import com.roome.domain.room.entity.Room;
 import com.roome.domain.room.exception.RoomAuthorizationException;
+import com.roome.domain.user.dto.request.SetProfileInfoRequest;
 import com.roome.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -45,6 +46,11 @@ public class User extends BaseTimeEntity {
 	// 자기 소개
 	@Column(length = 101)
 	private String bio;
+
+	@Enumerated(EnumType.STRING)
+	private Gender gender;
+
+	private Integer birthYear;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false, length = 10)
@@ -128,5 +134,10 @@ public class User extends BaseTimeEntity {
 
 	public void updateLastLogin(LocalDateTime now) {
 		this.lastLogin = now;
+	}
+
+	public void setProfileInfo(SetProfileInfoRequest setProfileInfoRequest) {
+		this.gender = setProfileInfoRequest.getGender();
+		this.birthYear = setProfileInfoRequest.getBirthYear();
 	}
 }

--- a/roome/src/main/java/com/roome/domain/user/service/UserProfileService.java
+++ b/roome/src/main/java/com/roome/domain/user/service/UserProfileService.java
@@ -3,6 +3,7 @@ package com.roome.domain.user.service;
 import com.roome.domain.houseMate.repository.HousemateRepository;
 import com.roome.domain.recommendedUser.service.RecommendedUserService;
 import com.roome.domain.user.dto.RecommendedUserDto;
+import com.roome.domain.user.dto.request.SetProfileInfoRequest;
 import com.roome.domain.user.dto.request.UpdateProfileRequest;
 import com.roome.domain.user.dto.response.UserProfileResponse;
 import com.roome.domain.user.entity.User;
@@ -10,23 +11,32 @@ import com.roome.domain.user.repository.UserRepository;
 import com.roome.domain.userGenrePreference.service.GenrePreferenceService;
 import com.roome.global.exception.BusinessException;
 import com.roome.global.exception.ErrorCode;
+import com.roome.global.security.jwt.exception.UserNotFoundException;
+import com.roome.global.security.jwt.principal.CustomUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class UserProfileService {
 
 	private final UserRepository userRepository;
 	private final HousemateRepository housemateRepository;
 	private final GenrePreferenceService genrePreferenceService;
 	private final RecommendedUserService recommendedUserService;
+
+	public void setProfileInfo(Long userId, SetProfileInfoRequest setProfileInfoRequest) {
+		Optional<User> user = userRepository.findById(userId);
+		if (user.isEmpty()) throw new UserNotFoundException();
+		user.get().setProfileInfo(setProfileInfoRequest);
+	}
 
 	public UserProfileResponse getUserProfile(Long userId, Long authUserId) {
 		// 사용자 정보 한 번만 조회

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -20,6 +20,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import static org.springframework.http.HttpMethod.PATCH;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -74,11 +76,9 @@ public class SecurityConfig {
 										.requestMatchers("/api/authenticate").permitAll()
 						                .requestMatchers("/login/oauth2/code/**").permitAll()
 										.requestMatchers("/oauth2/**").permitAll()
-//										.requestMatchers("/login").permitAll()
 										.requestMatchers("/api/auth/token/temp").permitAll()
 										.requestMatchers("/api/auth/token/refresh").permitAll()
-//										.requestMatchers(PathRequest.toH2Console()).permitAll()
-//                                .requestMatchers("/favicon.ico").permitAll()
+										.requestMatchers(PATCH, "/api/users/*/profile").permitAll()
 										.anyRequest().authenticated()
 				)
 				.oauth2Login(oauth2 -> oauth2

--- a/roome/src/main/java/com/roome/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/roome/src/main/java/com/roome/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -2,6 +2,7 @@ package com.roome.global.security.oauth.handler;
 
 import com.roome.global.security.jwt.service.TokenExchangeService;
 import com.roome.global.security.jwt.provider.JwtTokenProvider;
+import com.roome.global.security.oauth.model.CustomOAuth2User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 	private final JwtTokenProvider jwtTokenProvider;
 	private final TokenExchangeService tokenExchangeService;
 	@Value("${app.oauth2.redirectUri}")
-	private String frontendRedirectUri ; // 프론트 팀원들과 협의 필요
+	private String frontendRedirectUri ;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -30,8 +31,12 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 		// 임시 코드 발급 -> url 로 전달
 		String tempCode = tokenExchangeService.generateTempCode(accessToken);
 
-		// redirectUrl 로 tempCode 반환 -> test controller 로 간이 api 생성
-		String redirectUrl = frontendRedirectUri + "/login/callback?temp_code=" + tempCode;
+		// isNewUser 여부 추출
+		CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+		boolean isNewUser = oAuth2User.isNewUser();
+
+		// tempCode, isNewUser 함께 전달
+		String redirectUrl = frontendRedirectUri + "/login/callback?temp_code=" + tempCode + "&is_new_user=" + isNewUser;
 		response.sendRedirect(redirectUrl);
 	}
 }

--- a/roome/src/main/java/com/roome/global/security/oauth/model/CustomOAuth2User.java
+++ b/roome/src/main/java/com/roome/global/security/oauth/model/CustomOAuth2User.java
@@ -17,6 +17,7 @@ public class CustomOAuth2User implements OAuth2User, UserPrincipal {
 	private final User user;
 	private final Map<String, Object> attributes;
 	private final Long id;
+	private final boolean isNewUser;
 
 	@Override
 	public <A> A getAttribute(String name) {
@@ -50,5 +51,9 @@ public class CustomOAuth2User implements OAuth2User, UserPrincipal {
 
 	public User getUser() {
 		return user;
+	}
+
+	public boolean isNewUser() {
+		return isNewUser;
 	}
 }


### PR DESCRIPTION
## 📌 최초 로그인 시 성별, 연령대 수집 구현

### ✅ PR 설명

최초 로그인 시 성별, 연령대 수집 구현

### 🏗 작업 내용

- [ ] CustomOAuth2UserService에서 최초 로그인 판단 -> isNewUser 정보 전달
- [ ] OAuth2AuthenticationSuccessHandler에서 redirectUrl 에 isNewUser parameter 전달(프론트 처리 필요)
- [ ] 성별, 출생년도 수집 api 구현(token 전달 전 ->필터X)

### 📸 테스트 결과 (선택)

> 프론트 구현 후 테스트 필요 현재 api 테스트만 진행

### 🔗 관련 이슈 (선택)

> close #28 

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
