### PR TITLE
:sparkles: feat: api 유저별, 기능별 저장 구현

### DIFF
--- a/roome/src/main/java/com/roome/domain/apiUsage/entity/UserApiUsage.java
+++ b/roome/src/main/java/com/roome/domain/apiUsage/entity/UserApiUsage.java
@@ -1,0 +1,33 @@
+package com.roome.domain.apiUsage.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "user_api_usage")
+public class UserApiUsage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private String domain;
+    private String apiUri;
+    private LocalDate date;
+    private Long count;
+
+    @Builder
+    public UserApiUsage(Long userId, String domain, String apiUri, LocalDate date, Long count) {
+        this.userId = userId;
+        this.domain = domain;
+        this.apiUri = apiUri;
+        this.date = date;
+        this.count = count;
+    }
+}

--- a/roome/src/main/java/com/roome/domain/apiUsage/repository/UserApiUsageRepository.java
+++ b/roome/src/main/java/com/roome/domain/apiUsage/repository/UserApiUsageRepository.java
@@ -1,0 +1,9 @@
+package com.roome.domain.apiUsage.repository;
+
+import com.roome.domain.apiUsage.entity.UserApiUsage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserApiUsageRepository extends JpaRepository<UserApiUsage, Long> {
+}

--- a/roome/src/main/java/com/roome/domain/apiUsage/scheduler/ApiUsageScheduler.java
+++ b/roome/src/main/java/com/roome/domain/apiUsage/scheduler/ApiUsageScheduler.java
@@ -1,0 +1,18 @@
+package com.roome.domain.apiUsage.scheduler;
+
+import com.roome.domain.apiUsage.service.ApiUsageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ApiUsageScheduler {
+    private final ApiUsageService apiUsageService;
+
+    // 새벽 4시마다 실행
+    @Scheduled(cron = "0 0 4 * * *")
+    public void flushApiCounts() {
+        apiUsageService.flushCountsToDb();
+    }
+}

--- a/roome/src/main/java/com/roome/domain/apiUsage/service/ApiUsageCountService.java
+++ b/roome/src/main/java/com/roome/domain/apiUsage/service/ApiUsageCountService.java
@@ -1,0 +1,20 @@
+package com.roome.domain.apiUsage.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApiUsageCountService {
+
+    @Qualifier("apiCountRedisTemplate")
+    private final RedisTemplate<String, Long> apiCountRedisTemplate;
+
+    public void incrementCount(Long userId, String uri) {
+        // userId + uri 조합으로 카운트 증가
+        String key = "api_count:user:" + userId + ":" + uri;
+        apiCountRedisTemplate.opsForValue().increment(key);
+    }
+}

--- a/roome/src/main/java/com/roome/domain/apiUsage/service/ApiUsageService.java
+++ b/roome/src/main/java/com/roome/domain/apiUsage/service/ApiUsageService.java
@@ -1,0 +1,53 @@
+package com.roome.domain.apiUsage.service;
+
+import com.roome.domain.apiUsage.repository.UserApiUsageRepository;
+import com.roome.domain.apiUsage.entity.UserApiUsage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ApiUsageService {
+
+    @Qualifier("apiCountRedisTemplate")
+    private final RedisTemplate<String, Long> apiCountRedisTemplate;
+    private final UserApiUsageRepository userApiUsageRepository;
+
+    public void flushCountsToDb() {
+        // 1. Redis 키 스캔 (api_count:*)
+        Set<String> keys = apiCountRedisTemplate.keys("api_count:*");
+
+        if (keys == null) return;
+
+        for (String key : keys) {
+            long count = apiCountRedisTemplate.opsForValue().get(key);
+
+            String[] parts = key.split(":");
+            Long userId = Long.parseLong(parts[2]);
+            String uri = parts[3];
+            userApiUsageRepository.save(
+                    UserApiUsage.builder()
+                            .userId(userId)
+                            .domain(resolveDomain(uri))
+                            .apiUri(uri)
+                            .date(LocalDate.now())
+                            .count(count)
+                            .build()
+            );
+        }
+    }
+
+    private String resolveDomain(String uri) {
+        // "/api/auth/login" → ["", "api", "auth", "login"]
+        String[] parts = uri.split("/");
+        if (parts.length >= 3) {
+            return parts[2];
+        }
+        return "etc";
+    }
+}

--- a/roome/src/main/java/com/roome/global/config/RedisConfig.java
+++ b/roome/src/main/java/com/roome/global/config/RedisConfig.java
@@ -163,6 +163,15 @@ public class RedisConfig {
 		return template;
 	}
 
+    @Bean(name = "apiCountRedisTemplate")
+    public RedisTemplate<String, Long> apiCountRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+        return template;
+    }
+
 	@Bean
 	public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
 		ObjectMapper objectMapper = new ObjectMapper();

--- a/roome/src/main/java/com/roome/global/filter/ApiCountFilter.java
+++ b/roome/src/main/java/com/roome/global/filter/ApiCountFilter.java
@@ -1,0 +1,35 @@
+package com.roome.global.filter;
+
+import com.roome.domain.apiUsage.service.ApiUsageCountService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class ApiCountFilter extends OncePerRequestFilter {
+
+    private final ApiUsageCountService apiUsageCountService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String uri = request.getRequestURI();
+        String userId = request.getUserPrincipal() != null
+                ? request.getUserPrincipal().getName()
+                : "anonymous";
+
+        apiUsageCountService.incrementCount(Long.parseLong(userId), uri);
+
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## 📌 api 유저별, 기능별 저장 구현

### ✅ PR 설명

filter(요청 확인) -> redis 저장 -> 매일 새벽 4시 스케줄러로 DB 저장 -> redis 비우기

### 🏗 작업 내용

- [ ] api 유저별, 기능별 저장 구현

### 📸 테스트 결과 (선택)

> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)

> #35 

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
